### PR TITLE
Update: `.gitignore` (NuGet)

### DIFF
--- a/app/Kwality.CodeStyle/Kwality.CodeStyle.csproj
+++ b/app/Kwality.CodeStyle/Kwality.CodeStyle.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <NoDefaultExcludes>true</NoDefaultExcludes> <!-- Prevent files and folders starting with a `.` from being excluded. -->
     <Title>Kwality.CodeStyle</Title>
-    <Version>2.0.20</Version>
+    <Version>2.0.21</Version>
     <Authors>kdeconinck</Authors>
     <Description>IDE Settings, Roslyn Analyzers and PowerShell Scripts.</Description>
     <PackageProjectUrl>https://github.com/dotnet-essentials/Kwality.CodeStyle</PackageProjectUrl>

--- a/app/Kwality.CodeStyle/package/build/Kwality.CodeStyle.targets
+++ b/app/Kwality.CodeStyle/package/build/Kwality.CodeStyle.targets
@@ -15,7 +15,7 @@
 
   <!--  Copy the GIT files from the NuGet package. -->
   <Target Name="CopyGitFiles" BeforeTargets="BeforeBuild">
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\content\GIT\.gitignore" DestinationFolder="$(ProjectDir)\.Kwality.CodeStyle" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\content\GIT\.gitignore" DestinationFolder="$(ProjectDir)" SkipUnchangedFiles="true" />
   </Target>
 
   <!--  Copy the (Core) PowerShell script(s) from the NuGet package. -->

--- a/app/Kwality.CodeStyle/package/files/GIT/.gitignore
+++ b/app/Kwality.CodeStyle/package/files/GIT/.gitignore
@@ -6,8 +6,9 @@
 ## Changes to this file may cause incorrect behavior and will be lost when the file is generated again.
 ########################################################################################################################
 
-# Exclude the installed .NET Tools.
-dotnet-tools/
+# The `.Kwality.CodeStyle` folder.
+.Kwality.CodeStyle/
 
-# Exclude the `scripts/` folder.
-scripts/
+# Configuration files (IDE & Roslyn Analyzers).
+.editorconfig
+.globalconfig


### PR DESCRIPTION
- Update the NuGet package to copy the `.gitignore` file in the ROOT of the project instead of the in `.Kwality.CodeStyle/` folder.
- Update the `.gitignore` file to prevent the `.Kwality.CodeStyle/` folder, the `.editorconfig` file and the `.gitignore` file from being committed to the GIT repository.