### PR TITLE
Update: `.gitignore`

### DIFF
--- a/app/Kwality.CodeStyle/Kwality.CodeStyle.csproj
+++ b/app/Kwality.CodeStyle/Kwality.CodeStyle.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <NoDefaultExcludes>true</NoDefaultExcludes> <!-- Prevent files and folders starting with a `.` from being excluded. -->
     <Title>Kwality.CodeStyle</Title>
-    <Version>2.0.23</Version>
+    <Version>2.0.24</Version>
     <Authors>kdeconinck</Authors>
     <Description>IDE Settings, Roslyn Analyzers and PowerShell Scripts.</Description>
     <PackageProjectUrl>https://github.com/dotnet-essentials/Kwality.CodeStyle</PackageProjectUrl>

--- a/app/Kwality.CodeStyle/package/files/GIT/.gitignore
+++ b/app/Kwality.CodeStyle/package/files/GIT/.gitignore
@@ -8,3 +8,7 @@
 
 # The `.Kwality.CodeStyle` folder.
 .Kwality.CodeStyle/
+
+# IDE & Roslyn configuration files.
+.editorconfig
+.globalconfig


### PR DESCRIPTION
- Prevent the `.editorconfig` and `.globalconfig` files from being committed to the GIT repository.
- Bump the version number.